### PR TITLE
CASMSEC-518: Optimize cray-kyverno-policies-upstream chart for PolicyExceptions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ dep-up:
 test:
 	docker run --rm \
 		-v ${PWD}/charts:/apps \
-		${HELM_UNITTEST_IMAGE} -3 \
+		${HELM_UNITTEST_IMAGE} \
 		kyverno-policies
 
 package:

--- a/charts/kyverno-policies/Chart.yaml
+++ b/charts/kyverno-policies/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 type: application
 name: cray-kyverno-policies-upstream
-version: 1.0.0
-appVersion: v1.6.2
+version: 1.1.1
+appVersion: v1.13.2
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Kubernetes Pod Security Standards implemented as Kyverno policies
 keywords:
@@ -13,11 +13,11 @@ keywords:
 dependencies:
   - name: kyverno-policies
     repository: https://kyverno.github.io/kyverno/
-    version: v2.3.2
+    version: 3.3.2
 home: https://github.com/Cray-HPE/cray-kyverno-policies-upstream
 sources:
   - https://github.com/kyverno/policies
 maintainers:
-  - name: Nirmata
-    url: https://kyverno.io/
-kubeVersion: ">=1.16.0-0"
+  - name: csm-security-team
+    email: security_blr@hpe.com
+kubeVersion: ">=1.25.0-0"

--- a/charts/kyverno-policies/values.yaml
+++ b/charts/kyverno-policies/values.yaml
@@ -1,1 +1,24 @@
-
+kyverno-policies:
+  # Setting to `custom` to not include the default discrete PSS baseline policies from upstream
+  podSecurityStandard: custom
+  
+  # Providing the podSecurity subrule baseline policy as a custom policy in Audit mode
+  customPolicies:
+  - apiVersion: kyverno.io/v1
+    kind: ClusterPolicy
+    metadata:
+      name: podsecurity-subrule-baseline
+    spec:
+      background: true
+      validationFailureAction: Audit
+      rules:
+      - name: baseline
+        match:
+          any:
+          - resources:
+              kinds:
+              - Pod
+        validate:
+          podSecurity:
+            level: baseline
+            version: latest


### PR DESCRIPTION
## Summary and Scope

Overrided the `values.yaml` to skip deploying the upstream discrete baseline policies and manually provide a `podsecurity-subrule-baseline` ClusterPolicy to have easier PolicyExceptions, and centralized management of policies. More information at [Adoption Notes](https://rndwiki-pro.its.hpecorp.net/pages/viewpage.action?pageId=437162218#MigrationofPodSecurityPolicies(PSP)toKyverno(PodSecurityStandards(PSS))-AdoptionNotes).

## Issues and Related PRs

* Resolves [CASMSEC-518](https://jira-pro.it.hpe.com:8443/browse/CASMSEC-518)
* Change will also be needed in `release/1.7`

## Testing

[m13-kyv-upstream-policies-merge-test.txt](https://github.com/user-attachments/files/18951597/m13-kyv-upstream-policies-merge-test.txt)


### Tested on:

  * `mercury13.hpc.amslabs.hpecorp.net`
  * Mercury System

### Test description:

- Upgrade, Downgrade, Install, Uninstall Tested, logs attached.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable

