### PR TITLE
CASMSEC-545: Enable Enforce Mode in podsecurity-subrule-baseline

### DIFF
--- a/charts/kyverno-policies/Chart.yaml
+++ b/charts/kyverno-policies/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 type: application
 name: cray-kyverno-policies-upstream
-version: 1.1.1
-appVersion: v1.13.2
+version: 1.2.0
+appVersion: v1.13.4
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Kubernetes Pod Security Standards implemented as Kyverno policies
 keywords:
@@ -10,10 +10,11 @@ keywords:
   - policy agent
   - validating webhook
   - admissions controller
-dependencies:
-  - name: kyverno-policies
-    repository: https://kyverno.github.io/kyverno/
-    version: 3.3.2
+# Commenting the upstream dependency for now until they provide the subrule policy instead of discrete PSS policies
+# dependencies:
+#   - name: kyverno-policies
+#     repository: https://kyverno.github.io/kyverno/
+#     version: 3.3.2
 home: https://github.com/Cray-HPE/cray-kyverno-policies-upstream
 sources:
   - https://github.com/kyverno/policies

--- a/charts/kyverno-policies/templates/podsecurity-subrule-baseline.yaml
+++ b/charts/kyverno-policies/templates/podsecurity-subrule-baseline.yaml
@@ -1,0 +1,18 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: podsecurity-subrule-baseline
+spec:
+  background: true
+  validationFailureAction: {{ .Values.pssFailureAction }}
+  rules:
+  - name: baseline
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      podSecurity:
+        level: baseline
+        version: latest

--- a/charts/kyverno-policies/values.yaml
+++ b/charts/kyverno-policies/values.yaml
@@ -1,24 +1,2 @@
-kyverno-policies:
-  # Setting to `custom` to not include the default discrete PSS baseline policies from upstream
-  podSecurityStandard: custom
-  
-  # Providing the podSecurity subrule baseline policy as a custom policy in Audit mode
-  customPolicies:
-  - apiVersion: kyverno.io/v1
-    kind: ClusterPolicy
-    metadata:
-      name: podsecurity-subrule-baseline
-    spec:
-      background: true
-      validationFailureAction: Audit
-      rules:
-      - name: baseline
-        match:
-          any:
-          - resources:
-              kinds:
-              - Pod
-        validate:
-          podSecurity:
-            level: baseline
-            version: latest
+# Control validationFailureAction of PSS baseline policy
+pssFailureAction: Enforce


### PR DESCRIPTION
## Summary and Scope

Enabling Enforce Mode on podsecurity-subrule-baseline policy.

## Issues and Related PRs

* Resolves [CASMSEC-545](jira-pro.it.hpe.com:8443/browse/CASMSEC-545)

## Testing

### Tested on:

  * `wasp`

### Test description:

Install, Upgrade, Rollback Tested on `wasp`
[CASMSEC-545-wasp.txt](https://github.com/user-attachments/files/20278400/CASMSEC-545-wasp.txt)


## Risks and Mitigations

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

