### PR TITLE
CASMSEC-565: Revert back to Audit mode

### DIFF
--- a/charts/kyverno-policies/Chart.yaml
+++ b/charts/kyverno-policies/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: cray-kyverno-policies-upstream
-version: 1.2.0
+version: 1.2.1
 appVersion: v1.13.4
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Kubernetes Pod Security Standards implemented as Kyverno policies

--- a/charts/kyverno-policies/values.yaml
+++ b/charts/kyverno-policies/values.yaml
@@ -1,2 +1,2 @@
 # Control validationFailureAction of PSS baseline policy
-pssFailureAction: Enforce
+pssFailureAction: Audit


### PR DESCRIPTION
## Summary and Scope

As certain charts are still not adhering to the PSS policy, more exceptions are found to be required. This change reverts Enforce mode back to Audit mode so that installation and upgrade is not blocked.

## Issues and Related PRs

* Resolves [CASMSEC-565](https://jira-pro.it.hpe.com:8443/browse/CASMSEC-565)

## Testing


### Tested on:

  * `wasp`
  
### Test description:

Install tested on wasp
[CASMSEC-565-wasp.txt](https://github.com/user-attachments/files/20436476/CASMSEC-565-wasp.txt)


## Risks and Mitigations
None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

